### PR TITLE
Rename some Styles namespaces to Layout

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,16 +8,16 @@ AllCops:
 Rails:
   Enabled: true
 
-Style/AlignParameters:
+Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 
-Style/CaseIndentation:
+Layout/CaseIndentation:
   EnforcedStyle: end
 
 Style/AsciiComments:
   Enabled: false
 
-Style/IndentHash:
+Layout/IndentHash:
   Enabled: false
 
 Style/CollectionMethods:
@@ -42,7 +42,7 @@ Style/GuardClause:
 Style/IfUnlessModifier:
   Enabled: false
 
-Style/SpaceInsideHashLiteralBraces:
+Layout/SpaceInsideHashLiteralBraces:
   Enabled: false
 
 Style/Lambda:
@@ -78,10 +78,10 @@ Lint/EndAlignment:
 Style/FormatString:
   Enabled: false
 
-Style/MultilineMethodCallIndentation:
+Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
-Style/MultilineOperationIndentation:
+Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
 
 Style/WordArray:
@@ -90,7 +90,7 @@ Style/WordArray:
 Style/RedundantSelf:
   Enabled: false
 
-Style/AlignHash:
+Layout/AlignHash:
   Enabled: true
   EnforcedLastArgumentHashStyle: always_ignore
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,10 +14,23 @@ Layout/AlignParameters:
 Layout/CaseIndentation:
   EnforcedStyle: end
 
-Style/AsciiComments:
+Layout/IndentHash:
   Enabled: false
 
-Layout/IndentHash:
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+Layout/MultilineOperationIndentation:
+  EnforcedStyle: indented
+
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: false
+
+Layout/AlignHash:
+  Enabled: true
+  EnforcedLastArgumentHashStyle: always_ignore
+
+Style/AsciiComments:
   Enabled: false
 
 Style/CollectionMethods:
@@ -40,9 +53,6 @@ Style/GuardClause:
   Enabled: false
 
 Style/IfUnlessModifier:
-  Enabled: false
-
-Layout/SpaceInsideHashLiteralBraces:
   Enabled: false
 
 Style/Lambda:
@@ -78,21 +88,11 @@ Lint/EndAlignment:
 Style/FormatString:
   Enabled: false
 
-Layout/MultilineMethodCallIndentation:
-  EnforcedStyle: indented
-
-Layout/MultilineOperationIndentation:
-  EnforcedStyle: indented
-
 Style/WordArray:
   Enabled: false
 
 Style/RedundantSelf:
   Enabled: false
-
-Layout/AlignHash:
-  Enabled: true
-  EnforcedLastArgumentHashStyle: always_ignore
 
 Style/TrivialAccessors:
   AllowPredicates: true


### PR DESCRIPTION
When running rubocop in my machine I get the following messages

```
/Users/gabriel/.rubocop.yml: Style/AlignParameters has the wrong namespace - should be Layout
/Users/gabriel/.rubocop.yml: Style/CaseIndentation has the wrong namespace - should be Layout
/Users/gabriel/.rubocop.yml: Style/IndentHash has the wrong namespace - should be Layout
/Users/gabriel/.rubocop.yml: Style/SpaceInsideHashLiteralBraces has the wrong namespace - should be Layout
/Users/gabriel/.rubocop.yml: Style/MultilineMethodCallIndentation has the wrong namespace - should be Layout
/Users/gabriel/.rubocop.yml: Style/MultilineOperationIndentation has the wrong namespace - should be Layout
/Users/gabriel/.rubocop.yml: Style/AlignHash has the wrong namespace - should be Layout
```

This PR tries to fix those problems by renaming those namespaces.
I'm running rubocop 0.49.1

```
➜  linters git:(ggb-namespaces) rubocop -v
0.49.1
➜  linters git:(ggb-namespaces) uname -a
Darwin admins-MacBook-Pro.local 16.6.0 Darwin Kernel Version 16.6.0: Fri Apr 14 16:21:16 PDT 2017; root:xnu-3789.60.24~6/RELEASE_X86_64 x86_64
```