### PR TITLE
Move EndAlignment to Layout

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,9 @@ Layout/SpaceInsideHashLiteralBraces:
 Layout/AlignHash:
   Enabled: true
   EnforcedLastArgumentHashStyle: always_ignore
+  
+Layout/EndAlignment:
+  EnforcedStyleAlignWith: variable
 
 Style/AsciiComments:
   Enabled: false
@@ -81,9 +84,6 @@ Metrics/MethodLength:
 
 Style/SingleLineBlockParams:
   Enabled: false
-
-Lint/EndAlignment:
-  EnforcedStyleAlignWith: variable
 
 Style/FormatString:
   Enabled: false


### PR DESCRIPTION
.rubocop.yml: `Lint/EndAlignment` has the wrong namespace - should be `Layout`

-> https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/cop/layout/end_alignment.rb